### PR TITLE
unificación de la ruta post de agenda y envío de email cuando se crea un turno

### DIFF
--- a/api/src/routes/agendas.js
+++ b/api/src/routes/agendas.js
@@ -1,4 +1,6 @@
+const { default: axios } = require("axios");
 const { Router } = require("express");
+const { transporter } = require("../configs/nodemailer");
 const {
   Agenda,
   Especialista_medico,
@@ -13,39 +15,86 @@ const router = Router();
 router.post("/", async function (req, res) {
   let { date, amount, idSpecialist, idSpecialties } = req.body;
   try {
-    if (date && amount && idSpecialist && idSpecialties) {
-      const crearAgenda = await Agenda.create(
+    date.forEach(async (element) => {
+      let crearAgendas = await Agenda.create(
         {
-          date,
-          amount,
+          date: element,
+          amount: amount,
         },
         {
           fields: ["date", "amount"],
         }
       );
+
       const asignandoMedico = await Especialista_medico.findByPk(idSpecialist);
-      asignandoMedico
-        ? await crearAgenda.setEspecialista_medico(asignandoMedico)
-        : res.status(400).send({ msg: "Falta el medico especialista" });
+
+      await crearAgendas.setEspecialista_medico(asignandoMedico);
 
       const asignandoEspecialidad = await Tipo_especialidad.findByPk(
         idSpecialties
       );
-      asignandoEspecialidad
-        ? await crearAgenda.setTipo_especialidad(asignandoEspecialidad)
-        : res.status(400).send({ msg: "Falta la especialidad" });
-      res.status(200).send(crearAgenda);
-    } else {
-      res.status(400).send({ msg: "No se pudo crear la agenda" });
-    }
+      await crearAgendas.setTipo_especialidad(asignandoEspecialidad);
+    });
+    res.status(200).send({ msg: "Agendas creadas" });
   } catch (e) {
-    res.status(400).send({ msg: "No se pudo crear la agenda" });
+    res.status(400).send({ msg: "No se puedo crear el grupo de agendas" });
   }
 });
 
 router.get("/", async function (req, res) {
   try {
     let totalAgendas = await Agenda.findAll({
+      attributes: { exclude: ["especialistaMedicoId", "tipoEspecialidadId"] },
+      include: [
+        {
+          //attributes:["id","date","amount"],
+          model: Especialista_medico,
+          attributes: { exclude: ["enrollment", "specialty"] },
+          include: {
+            model: Persona,
+            attributes: ["name", "lastName"],
+          },
+        },
+        {
+          model: Tipo_especialidad,
+        },
+        {
+          model: Turno,
+          attributes: { exclude: ["modules", "agendaId", "pacienteId"] },
+          include: {
+            model: Paciente,
+            attributes: {
+              exclude: [
+                "medication",
+                "personaId",
+                "emergencyContact",
+                "disease",
+              ],
+            },
+            include: [
+              {
+                model: Persona,
+                attributes: ["name", "lastName"],
+              },
+              {
+                model: HistoriaClinica,
+                attributes: ["id"],
+              },
+            ],
+          },
+        },
+      ],
+    });
+    res.status(200).send(totalAgendas);
+  } catch (e) {
+    res.status(400).send({ msg: "No se pudo encontrar las agendas" });
+  }
+});
+
+router.get("/agendaId/:id", async function (req, res) {
+  let id = req.params.id;
+  try {
+    let totalAgendas = await Agenda.findByPk(id, {
       attributes: { exclude: ["especialistaMedicoId", "tipoEspecialidadId"] },
       include: [
         {

--- a/api/src/routes/turno.js
+++ b/api/src/routes/turno.js
@@ -1,4 +1,5 @@
 const { Router } = require("express");
+const { transporter } = require("../configs/nodemailer");
 const {
   Agenda,
   Turno,
@@ -25,6 +26,8 @@ router.post("/", async function (req, res) {
     );
 
     const asignandoAgenda = await Agenda.findByPk(agendaId);
+    let { date } = asignandoAgenda.dataValues;
+
     asignandoAgenda
       ? await crearTurno.setAgenda(asignandoAgenda)
       : res
@@ -32,9 +35,30 @@ router.post("/", async function (req, res) {
           .send({ msg: "No se pudo encontrar la agenda indicada" });
 
     const asignandoPaciente = await Paciente.findByPk(pacienteId);
+
     asignandoPaciente
       ? await crearTurno.setPaciente(asignandoPaciente)
       : res.status(400).send({ msg: "No se pudo encontrar el paciente" });
+
+    let datosPersona = await Persona.findByPk(
+      asignandoPaciente.dataValues.personaId
+    );
+    let { name, lastName, email } = datosPersona.dataValues;
+
+    let datosAgenda = await Tipo_especialidad.findByPk(
+      asignandoAgenda.dataValues.tipoEspecialidadId
+    );
+    let nameSpecialties = datosAgenda.dataValues.name;
+
+    if (email) {
+      await transporter.sendMail({
+        from: '"GesSalud💉" <ges.salud.04@gmail.com>',
+        to: email,
+        subject: "Turno asignado ✔",
+        html: `<b> Hola ${name} ${lastName}🩺 , </br>
+        tu tunrno para: ${nameSpecialties} fue asignado para el ${date} a las ${hour} </b>`,
+      });
+    }
 
     res.status(200).send(crearTurno);
   } catch (e) {


### PR DESCRIPTION
ya no se encuentra la ruta de prueba de creación de múltiples agendas. la propiedad date de agenda, deben enviarla al back cómo un array aunque sea un solo dato.